### PR TITLE
model: Rumina-m1-ProMaxを搭載 #32

### DIFF
--- a/backend/app/api/modules/tts_wrappers/openai_tts.py
+++ b/backend/app/api/modules/tts_wrappers/openai_tts.py
@@ -1,0 +1,46 @@
+import base64
+import os
+
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class OpenAI_TTS:
+    def __init__(self, model: str = "tts-1", voice: str = "alloy"):
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        self.tts_model = model
+        self.voice = voice
+
+    def generate(self, text: str) -> bytes:
+        """
+        テキストから音声（音声バイナリ）を生成する
+        :param text: 合成したいテキスト
+        :return: 音声データ（mp3形式のバイナリ）
+        """
+        response = openai.audio.speech.create(
+            model=self.tts_model,
+            voice=self.voice,
+            input=text,
+        )
+        return response.content  # バイナリデータを返す
+
+    def synthesize_to_base64(self, text: str) -> str:
+        """
+        テキストをMP3形式で音声合成し、Base64エンコードされた文字列を返す
+        :param text: 合成したいテキスト
+        :return: Base64文字列（mp3）
+        """
+        audio_bytes = self.generate(text)
+        return base64.b64encode(audio_bytes).decode("utf-8")
+
+
+# # 使用例
+# if __name__ == "__main__":
+#     tts = OpenAI_TTS(model="tts-1", voice="shimmer")
+#     audio_data = tts.generate("こんにちは、OpenAIのTTSを使っています。")
+
+#     # ファイルとして保存する場合
+#     with open("output.mp3", "wb") as f:
+#         f.write(audio_data)

--- a/backend/app/api/modules/tts_wrappers/style_bert_vits2_wrapper.py
+++ b/backend/app/api/modules/tts_wrappers/style_bert_vits2_wrapper.py
@@ -62,15 +62,15 @@ class RuminaStyleBertVITS2Wrapper:
         return base64.b64encode(buffer.read()).decode("utf-8")
 
 
-model_dir = (
-    "/workspace/backend/app/model/tts/richika_v1"  # モデルのディレクトリを指定
-)
-device = "cpu"  # または "cpu"
-wrapper = RuminaStyleBertVITS2Wrapper(model_dir=model_dir, device=device)
+# model_dir = (
+#     "/workspace/backend/app/model/tts/richika_v1"  # モデルのディレクトリを指定
+# )
+# device = "cpu"  # または "cpu"
+# wrapper = RuminaStyleBertVITS2Wrapper(model_dir=model_dir, device=device)
 
-output_wav = "output_test.wav"
-test_text = "こんにちは。私はRuminaです。あなたの声で話しています。"
+# output_wav = "output_test.wav"
+# test_text = "こんにちは。私はRuminaです。あなたの声で話しています。"
 
-wrapper.generate(text=test_text, output_path=output_wav)
+# wrapper.generate(text=test_text, output_path=output_wav)
 
-print(f"✅ 音声が生成されました: {output_wav}")
+# print(f"✅ 音声が生成されました: {output_wav}")

--- a/backend/app/api/utils/model_selector.py
+++ b/backend/app/api/utils/model_selector.py
@@ -5,6 +5,7 @@ from api.modules.transcribers.transcribers import (
     OpenAITranscriber,
     WhisperLocalTranscriber,
 )
+from api.modules.tts_wrappers.openai_tts import OpenAI_TTS
 from api.modules.tts_wrappers.style_bert_vits2_wrapper import (
     RuminaStyleBertVITS2Wrapper,
 )
@@ -23,6 +24,10 @@ def get_transcriber_instance(model_name: str):
         print("🔊 OpenAITranscriber を使用")
         openai_transcriber = OpenAITranscriber()
         return openai_transcriber
+    elif model_name == "rumina-m1-promax":
+        print("🔊 OpenAITranscriber を使用")
+        openai_transcriber = OpenAITranscriber()
+        return openai_transcriber
     else:
         raise ValueError(f"Unsupported model: {model_name}")
 
@@ -32,6 +37,8 @@ def get_multimodal_response_func(model_name: str):
         return get_multimodal_response
     elif model_name == "rumina-m1-pro":
         return get_multimodal_response
+    elif model_name == "rumina-m1-promax":
+        return get_multimodal_response
     else:
         raise ValueError(f"Unsupported model: {model_name}")
 
@@ -40,6 +47,7 @@ tts_instance = TTSGenerator()
 rumina_tts_instance = RuminaStyleBertVITS2Wrapper(
     model_dir="/workspace/backend/app/model/tts/richika_v1", device=device
 )
+openai_tts_instance = OpenAI_TTS()
 
 
 def get_tts_instance(model_name: str):
@@ -47,5 +55,7 @@ def get_tts_instance(model_name: str):
         return tts_instance
     elif model_name == "rumina-m1-pro":
         return rumina_tts_instance
+    elif model_name == "rumina-m1-promax":
+        return openai_tts_instance
     else:
         raise ValueError(f"Unsupported model: {model_name}")

--- a/frontend/components/molecules/ModelSelector/index.tsx
+++ b/frontend/components/molecules/ModelSelector/index.tsx
@@ -11,6 +11,7 @@ type ModelSelectorProps = {
 const models = [
     { key: "rumina-m1", label: "M1", description: "視覚入力も対応した標準モデル" },
     { key: "rumina-m1-pro", label: "M1-Pro", description: "音声認識が高精度かつ高速" },
+    { key: "rumina-m1-promax", label: "M1-ProMax", description: "品質が高い応答性能を持つモデ" },
     { key: "rumina-m1-server", label: "m1-server", description: "視覚入力も対応した初期モデル" },
     { key: "rumina-c1-server", label: "c1-server", description: "軽量かつ高速な言語入力のみモデル" },
 ];

--- a/frontend/features/chat/utils/getModeFromModel.ts
+++ b/frontend/features/chat/utils/getModeFromModel.ts
@@ -11,6 +11,8 @@ export const getModeFromModel = (modelKey: string): {
             return { Mode: "image", vadMode: "client-vad", modelKey };
         case "rumina-m1-pro":
             return { Mode: "image", vadMode: "client-vad", modelKey };
+        case "rumina-m1-promax":
+            return { Mode: "image", vadMode: "client-vad", modelKey }
         case "rumina-m1-server":
             return { Mode: "image", vadMode: "server-vad", modelKey };
         case "rumina-c1-server":


### PR DESCRIPTION
## 概要
新モデル `Rumina-m1-ProMax` を追加し、音声合成に OpenAI TTS API を利用可能にしました。これにより、より高精度かつ高速な音声合成を選択できるようになります。


## 変更内容
- `openai_tts.py`: OpenAI TTS API を呼び出すクラス `OpenAI_TTS` を新規実装  
- `style_bert_vits2_wrapper.py`: テスト・デバッグ用コードをコメントアウト  
- バックエンド: モデルセレクターに `Rumina-m1-ProMax` の条件を追加  
- フロントエンド: モデル選択UIに `Rumina-m1-ProMax` を追加し選択可能に  